### PR TITLE
Upgrade sequelize and minor fixes

### DIFF
--- a/migrations/migrations/20190508143516-create-user.js
+++ b/migrations/migrations/20190508143516-create-user.js
@@ -7,11 +7,11 @@ module.exports = {
         allowNull: false,
         primaryKey: true
       },
-      firstName: {
+      first_name: {
         type: Sequelize.STRING,
         allowNull: false
       },
-      lastName: {
+      last_name: {
         type: Sequelize.STRING,
         allowNull: false
       },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "apollo-server": "^2.4.8",
     "cors": "^2.8.4",
-    "express-wolox-logger": "0.0.1",
+    "express-wolox-logger": "^1.0.0",
     "graphql": "^14.2.1",
     "graphql-tools": "^4.0.4",
     "jwt-simple": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   },
   "scripts": {
     "console": "node console.js",
-    "cover": "NODE_ENV=testing jest --coverage --runInBand --forceExit test/app",
-    "test": "NODE_ENV=testing jest test/app --runInBand --forceExit",
-    "test-inspect": "NODE_ENV=testing node --inspect --debug-brk jest test/app.spec.js",
+    "cover": "NODE_ENV=testing npm run test -- --coverage",
+    "test": "NODE_ENV=testing jest test/app --runInBand --forceExit --detectOpenHandles",
+    "test-inspect": "NODE_ENV=testing node --inspect --debug-brk jest test/app",
     "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls",
     "eslint-check": "eslint --print-config .eslintrc.js --ignore-pattern ./.eslintrc.js | eslint-config-prettier-check",
     "lint": "eslint \"**/*.js\" --ignore-pattern ./.eslintrc.js",
@@ -21,7 +21,7 @@
     "pretest": "npm run lint",
     "prestart": "npm run lint",
     "migrations": "sequelize db:migrate",
-    "migrations-test": "NODE_ENV=testing sequelize db:migrate",
+    "migrations-test": "NODE_ENV=testing npm run migrations",
     "start": "nodemon --inspect server.js"
   },
   "cacheDirectories": [

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jwt-simple": "^0.5.1",
     "pg": "^7.4.1",
     "rollbar": "^2.3.9",
-    "sequelize": "^4.44.0",
+    "sequelize": "^6.0.0",
     "umzug": "^2.1.0"
   },
   "devDependencies": {

--- a/test/users/resolvers.spec.js
+++ b/test/users/resolvers.spec.js
@@ -13,8 +13,8 @@ describe('users', () => {
           expect(res.dataValues).toHaveProperty('email');
           expect(res.dataValues).toHaveProperty('username');
           expect(res.dataValues).toHaveProperty('password');
-          expect(res.dataValues).toHaveProperty('updated_at');
-          expect(res.dataValues).toHaveProperty('created_at');
+          expect(res.dataValues).toHaveProperty('updatedAt');
+          expect(res.dataValues).toHaveProperty('createdAt');
         });
       });
 


### PR DESCRIPTION
## Summary

- Upgrade `sequelize` to 'v6.0.0'. 
- Refactor migrations. 
- Minor improvements in node scripts.
- Upgrade node-express-logger to latest version.

## Known Issues

None


