### PR TITLE
change sequelize version 6.0.0 to 5.21.4 or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lodash.merge": "^4.6.2",
     "pg": "^7.4.1",
     "rollbar": "^2.3.9",
-    "sequelize": "^6.0.0",
+    "sequelize": "^5.21.4",
     "umzug": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Downgrade Sequelize to stable version